### PR TITLE
feat: more snapshot options for buckets.

### DIFF
--- a/buckets/buckets.go
+++ b/buckets/buckets.go
@@ -36,26 +36,3 @@ REDO:
 	}
 	val.v.Add(1)
 }
-
-// Snapshot gets the current bucket statistics snapshot.
-func (b *bucketsRecorder) Snapshot(sp recorder.RecordedSnapshot) {
-
-	if b.opt.clearAfterSnapshot {
-		var keys []duration.Duration
-		b.mp.IterCb(func(key duration.Duration, v counter) {
-			keys = append(keys, key)
-		})
-		for _, key := range keys {
-			v, ok := b.mp.Pop(key)
-			if ok {
-				sp[key] += v.v.Load()
-				v.recycle()
-			}
-		}
-	} else {
-		b.mp.IterCb(func(key duration.Duration, v counter) {
-			sp[key] += v.v.Load()
-		})
-	}
-
-}

--- a/buckets/option.go
+++ b/buckets/option.go
@@ -1,8 +1,8 @@
 package buckets
 
 type option struct {
-	allocator          BucketAllocator
-	clearAfterSnapshot bool
+	allocator    BucketAllocator
+	snapshotFunc SnapshotOperation
 }
 
 // Option bucket configuration.
@@ -16,14 +16,19 @@ func WithBucketAllocator(sf BucketAllocator) Option {
 	}
 }
 
-// WithClearAfterSnapshot set to clear the buckets after Snapshot.
-func WithClearAfterSnapshot() Option {
+// WithSnapshotOperation sets the SnapshotOperation (default is OnlySnapshot).
+// SnapshotOperation is provided by the buckets package.
+//
+//	Example:
+//
+// WithSnapshotOperation(CleanupAfterSnapshot(6))
+func WithSnapshotOperation(op SnapshotOperation) Option {
 	return func(o *option) {
-		o.clearAfterSnapshot = true
+		o.snapshotFunc = op
 	}
 }
 
 var defaultOption = option{
-	allocator:          BestBucketAllocator(),
-	clearAfterSnapshot: false,
+	allocator:    BestBucketAllocator(),
+	snapshotFunc: OnlySnapshot(),
 }

--- a/buckets/snapshot.go
+++ b/buckets/snapshot.go
@@ -1,0 +1,109 @@
+package buckets
+
+import (
+	"github.com/jhue58/latency/duration"
+	"github.com/jhue58/latency/recorder"
+	cmap "github.com/orcaman/concurrent-map/v2"
+	"sync"
+	"sync/atomic"
+)
+
+// SnapshotOperation is a function that performs an operation get map snapshot.
+type SnapshotOperation func(mp cmap.ConcurrentMap[duration.Duration, counter], sp recorder.RecordedSnapshot)
+
+// Snapshot gets the current bucket statistics snapshot.
+func (b *bucketsRecorder) Snapshot(sp recorder.RecordedSnapshot) {
+	b.opt.snapshotFunc(b.mp, sp)
+}
+
+// CleanupAfterSnapshot returns a SnapshotOperation that performs cleanup
+// after a specified number of operations (cleanupInterval).
+func CleanupAfterSnapshot(cleanupInterval uint64) SnapshotOperation {
+	if cleanupInterval <= 0 {
+		cleanupInterval = 1
+	}
+	intervalI64 := int64(cleanupInterval)
+	var count atomic.Int64
+	return func(mp cmap.ConcurrentMap[duration.Duration, counter], sp recorder.RecordedSnapshot) {
+	RETRY:
+		added := count.Add(1)
+		if added < intervalI64 {
+			mp.IterCb(func(key duration.Duration, v counter) {
+				sp[key] += v.v.Load()
+			})
+		} else if added == intervalI64 {
+			var keys []duration.Duration
+			count.Store(0)
+			mp.IterCb(func(key duration.Duration, v counter) {
+				keys = append(keys, key)
+			})
+			for _, key := range keys {
+				v, ok := mp.Pop(key)
+				if ok {
+					sp[key] += v.v.Load()
+					v.recycle()
+				}
+			}
+		} else {
+			goto RETRY
+		}
+
+	}
+}
+
+// CleanupAndThenSwitch returns a SnapshotOperation that performs cleanup
+// after a specified number of operations (cleanupInterval), and then switches
+// to the provided SnapshotOperation.
+func CleanupAndThenSwitch(cleanupInterval uint64, to SnapshotOperation) SnapshotOperation {
+	if cleanupInterval <= 0 {
+		cleanupInterval = 1
+	}
+	intervalI64 := int64(cleanupInterval)
+	var count atomic.Int64
+	var cleaned atomic.Bool
+	var cleanLock sync.RWMutex
+
+	return func(mp cmap.ConcurrentMap[duration.Duration, counter], sp recorder.RecordedSnapshot) {
+	RETRY:
+		if cleaned.Load() {
+			cleanLock.RLock()
+			to(mp, sp)
+			cleanLock.RUnlock()
+			return
+		}
+		added := count.Add(1)
+		if added < intervalI64 {
+			mp.IterCb(func(key duration.Duration, v counter) {
+				sp[key] += v.v.Load()
+			})
+		} else if added == intervalI64 {
+			var keys []duration.Duration
+			cleanLock.Lock()
+			defer cleanLock.Unlock()
+			cleaned.Store(true)
+			mp.IterCb(func(key duration.Duration, v counter) {
+				keys = append(keys, key)
+			})
+			for _, key := range keys {
+				v, ok := mp.Pop(key)
+				if ok {
+					sp[key] += v.v.Load()
+					v.recycle()
+				}
+			}
+		} else {
+			goto RETRY
+		}
+
+	}
+
+}
+
+// OnlySnapshot returns a SnapshotOperation.
+func OnlySnapshot() SnapshotOperation {
+	return func(mp cmap.ConcurrentMap[duration.Duration, counter], sp recorder.RecordedSnapshot) {
+		mp.IterCb(func(key duration.Duration, v counter) {
+			sp[key] += v.v.Load()
+		})
+	}
+}

--- a/buckets/snapshot_test.go
+++ b/buckets/snapshot_test.go
@@ -1,0 +1,60 @@
+package buckets
+
+import (
+	"github.com/jhue58/latency/duration"
+	"github.com/jhue58/latency/recorder"
+	"github.com/stretchr/testify/assert"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCleanupAfterSnapshot(t *testing.T) {
+	wg := sync.WaitGroup{}
+	cleanupInterval := 10
+	b := NewBucketsRecorder(WithSnapshotOperation(CleanupAfterSnapshot(uint64(cleanupInterval))))
+
+	for i := 0; i < cleanupInterval*2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Record(duration.NewDuration(time.Duration(rand.Int64())))
+			sp := recorder.RecordedSnapshot{}
+			b.Snapshot(sp)
+			assert.False(t, sp.IsEmpty())
+		}()
+	}
+	wg.Wait()
+	sp := recorder.RecordedSnapshot{}
+	b.Snapshot(sp)
+	assert.True(t, sp.IsEmpty())
+
+}
+
+func TestCleanupAndThenSwitch(t *testing.T) {
+	wg := sync.WaitGroup{}
+	cleanupInterval := 10
+	b := NewBucketsRecorder(WithSnapshotOperation(CleanupAndThenSwitch(uint64(cleanupInterval), OnlySnapshot())))
+
+	for i := 0; i < cleanupInterval*2; i++ {
+		if i == cleanupInterval {
+			wg.Wait()
+			sp := recorder.RecordedSnapshot{}
+			b.Snapshot(sp)
+			assert.True(t, sp.IsEmpty())
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Record(duration.NewDuration(time.Duration(rand.Int64())))
+			sp := recorder.RecordedSnapshot{}
+			b.Snapshot(sp)
+			assert.False(t, sp.IsEmpty())
+		}()
+	}
+	wg.Wait()
+	sp := recorder.RecordedSnapshot{}
+	b.Snapshot(sp)
+	assert.False(t, sp.IsEmpty())
+}

--- a/format.go
+++ b/format.go
@@ -10,6 +10,7 @@ type FormatFunc func(sp recorder.RecordedSnapshot) string
 
 // DefaultFormat contains max,min,mean,p50,p90,p99,p999
 func DefaultFormat(sp recorder.RecordedSnapshot) string {
+	count := sp.Count()
 	mmax := sp.Max()
 	mmin := sp.Min()
 	mean := sp.Mean()
@@ -17,7 +18,8 @@ func DefaultFormat(sp recorder.RecordedSnapshot) string {
 	p90 := sp.Percentile(90)
 	p99 := sp.Percentile(99)
 	p999 := sp.Percentile(99.9)
-	str := fmt.Sprintf("max:%s min:%s mean:%s p50:%s p90:%s p99:%s p999:%s",
+	str := fmt.Sprintf("count:%d max:%s min:%s mean:%s p50:%s p90:%s p99:%s p999:%s",
+		count,
 		mmax.String(),
 		mmin.String(),
 		mean.String(),

--- a/recorder/snapshot.go
+++ b/recorder/snapshot.go
@@ -75,6 +75,14 @@ func (s RecordedSnapshot) Percentile(percent float64) (res duration.Duration) {
 	return
 }
 
+// Count returns the count of the current snapshot.
+func (s RecordedSnapshot) Count() (count int64) {
+	for _, c := range s {
+		count += c
+	}
+	return
+}
+
 func (s RecordedSnapshot) IsEmpty() bool {
 	return len(s) <= 0
 }


### PR DESCRIPTION
- More [snapshot options][snapshot options] for buckets.
- [Count][count] func for RecorderSnapshot.
- [DefaultFormat][defaultFormat] can format the count of snapshot.

[snapshot options]: buckets/snapshot.go
[count]: recorder/snapshot.go
[defaultFormat]: format.go
